### PR TITLE
Add support for psycopg3

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This package is tested against:
 - Python 3.10, 3.11, or 3.12.
 - Django 4.1, 4.2, or 5.0.
 - PostgreSQL 12 to 16
+- psycopg2 and psycopg3
 
 ## Local development
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,9 +20,11 @@ name = "django_integrity"
 version = "0.0-alpha"
 requires-python = ">=3.10"
 dependencies = [
-    # Psycopg2 is required, but we do not include it here.
-    # We cannot decide for users if they want to use psycopg2 or psycopg2-binary.
+    # We cannot decide for users if they want to use psycopg2, psycopg2-binary, or
+    # psycopg (i.e. psycopg3) with or without the [binary] extra. It should be part of
+    # their own project dependencies anyway.
     # See https://www.psycopg.org/docs/install.html#psycopg-vs-psycopg-binary
+    # See https://www.psycopg.org/psycopg3/docs/basic/install.html#binary-installation
 ]
 classifiers = [
   "Development Status :: 3 - Alpha",

--- a/src/django_integrity/constraints.py
+++ b/src/django_integrity/constraints.py
@@ -2,7 +2,11 @@ import contextlib
 from collections.abc import Iterator, Sequence
 
 from django import db as django_db
-from psycopg2 import sql
+
+try:
+    from psycopg import sql
+except ImportError:
+    from psycopg2 import sql
 
 
 # Note [Deferrable constraints]

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,19 @@
 [tox]
 min_version = 4.0
 env_list =
-    py312-django{42,50}
-    py311-django{41,42,50}
-    py310-django{41,42,50}
+    py3{10,11}-django41-psycopg2
+    py3{10,11,12}-django{42,50}-psycopg{2,3}
 
 [testenv]
 pass_env =
     DATABASE_URL
 deps =
     -r requirements/development.txt
-    psycopg2-binary
     django41: django>=4.1,<4.2
     django42: django>=4.2,<5.0
     django50: django>=5.0,<5.1
+    psycopg2: psycopg2-binary
+    psycopg3: psycopg[binary]
 
 commands =
     python -m pytest


### PR DESCRIPTION
Django 4.2+ supports psycopg3 and will prefer it over psycopg2 if it is installed. Follow the same approach here to ensure that this package behaves in a manner consistent with Django itself.