### PR TITLE
Rename the linting job

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -7,7 +7,7 @@ on:
       - main
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-22.04
     timeout-minutes: 3
 


### PR DESCRIPTION
This is currently showing up in the check summary as "Linting / build",
which is a bit confusing.
