### PR TITLE
Check release type instead of branch when releasing

### DIFF
--- a/.github/workflows/release-to-pypi.yaml
+++ b/.github/workflows/release-to-pypi.yaml
@@ -23,7 +23,7 @@ jobs:
     name: Verify versions
     runs-on: ubuntu-22.04
     timeout-minutes: 5
-    if: github.repository_owner == 'kraken-tech' && github.ref == 'refs/heads/main'
+    if: github.repository_owner == 'kraken-tech' && github.ref_type == 'tag'
 
     steps:
       - name: Clone the code
@@ -43,7 +43,7 @@ jobs:
   release:
     name: Publish to pypi.org
     environment: release
-    if: github.repository_owner == 'kraken-tech' && github.ref == 'refs/heads/main'
+    if: github.repository_owner == 'kraken-tech' && github.ref_type == 'tag'
     needs: [build, verify]
     runs-on: ubuntu-22.04
     timeout-minutes: 5


### PR DESCRIPTION
Before this change, we checked the branch name, but we're reacting to pushed tags, so that did nothing.

This change switches over to checking that we're reacting to a tag. This way we'll still be able to partially run this in PRs to check that the build works, without making any attempt to push to PyPI.