### PR TITLE
Prepare v0.1.0 for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,12 @@
 All notable changes to this project will be documented in this file.
 
 ## Unreleased changes
+
+## v0.1.0 - 2024-05-07
+
+- Initial release! WOO!
+- Tested against sensible combinations of:
+    - Python 3.10, 3.11, and 3.12.
+    - Django 4.1, 4.2, and 5.0.
+    - PostgreSQL 12 to 16.
+    - psycopg2 and psycopg3.

--- a/README.md
+++ b/README.md
@@ -95,5 +95,5 @@ This package is tested against:
 
 - Python 3.10, 3.11, or 3.12.
 - Django 4.1, 4.2, or 5.0.
-- PostgreSQL 12 to 16
-- psycopg2 and psycopg3
+- PostgreSQL 12 to 16.
+- psycopg2 and psycopg3.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ where = ["src"]
 
 [project]
 name = "django_integrity"
-version = "0.0-alpha"
+version = "0.1.0"
 license.file = "LICENSE"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
This paves the way for the initial release.

Once merged, a matching tag will need to be pushed.