### PR TITLE
Allow passing arguments to pytest via tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -16,4 +16,4 @@ deps =
     psycopg3: psycopg[binary]
 
 commands =
-    python -m pytest
+    python -m pytest {posargs}


### PR DESCRIPTION
So, e.g, we can only run one test, module or package.