### PR TITLE
Fix some mistaken type signatures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased changes
 
+- Fix some incorrect type signatures.
+  We were mistakenly asking for `django.db.models.Model` instead of `type[django_db.models.Model]` in:
+    - `django_integrity.constraints.foreign_key_constraint_name`
+    - `django_integrity.conversion.Unique`
+    - `django_integrity.conversion.PrimaryKey`
+    - `django_integrity.conversion.NotNull`
+    - `django_integrity.conversion.ForeignKey`
+
 ## v0.1.0 - 2024-05-07
 
 - Initial release! WOO!

--- a/src/django_integrity/constraints.py
+++ b/src/django_integrity/constraints.py
@@ -160,7 +160,7 @@ class NotInTransaction(Exception):
 
 
 def foreign_key_constraint_name(
-    model: django_db.models.Model, field_name: str, *, using: str
+    model: type[django_db.models.Model], field_name: str, *, using: str
 ) -> str:
     """
     Calculate FK constraint name for a model's field.

--- a/src/django_integrity/conversion.py
+++ b/src/django_integrity/conversion.py
@@ -74,7 +74,7 @@ class Unique(_Rule):
     A unique constraint defined by a model and a set of fields.
     """
 
-    model: django_db.models.Model
+    model: type[django_db.models.Model]
     fields: tuple[str]
 
     _pattern = re.compile(r"Key \((?P<fields>.+)\)=\(.*\) already exists.")
@@ -102,7 +102,7 @@ class PrimaryKey(_Rule):
     trying to create a PrimaryKey rule.
     """
 
-    model: django_db.models.Model
+    model: type[django_db.models.Model]
 
     _pattern = re.compile(r"Key \((?P<fields>.+)\)=\(.*\) already exists.")
 
@@ -149,7 +149,7 @@ class NotNull(_Rule):
     A not-null constraint on a Model's field.
     """
 
-    model: django_db.models.Model
+    model: type[django_db.models.Model]
     field: str
 
     def is_match(self, error: django_db.IntegrityError) -> bool:
@@ -168,7 +168,7 @@ class ForeignKey(_Rule):
     A foreign key constraint on a Model's field.
     """
 
-    model: django_db.models.Model
+    model: type[django_db.models.Model]
     field: str
 
     _detail_pattern = re.compile(


### PR DESCRIPTION
These signatures were incorrectly demanding Django Model instances, where they should have required Django Model classes instead.

This change fixes the mistaken types, but does not yet fix the fact that [our Mypy pipeline is broken](https://github.com/kraken-tech/django-integrity/issues/26), which should have picked this up. I'll try to release this quickly, and address that in another PR.