### PR TITLE
Fix project URLs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,8 +45,8 @@ classifiers = [
 [project.urls]
 # See https://daniel.feldroy.com/posts/2023-08-pypi-project-urls-cheatsheet for
 # additional URLs that can be included here.
-repository = "https://github.com/octoenergy/django-integrity"
-changelog = "https://github.com/octoenergy/django-integrity/blob/main/CHANGELOG.md"
+repository = "https://github.com/kraken-tech/django-integrity"
+changelog = "https://github.com/kraken-tech/django-integrity/blob/main/CHANGELOG.md"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
These listed the project's old URL, before it was moved to the
`kraken-tech` organisation.

Fixes #24
