### PR TITLE
Install (and re-use) wheels in Tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,12 @@ env_list =
     py3{10,11,12}-django{42,50}-psycopg{2,3}
 
 [testenv]
+# Install wheels instead of source distributions for faster execution.
+package = wheel
+
+# Share the build environment between tox environments.
+wheel_build_env = .pkg
+
 pass_env =
     DATABASE_URL
 deps =


### PR DESCRIPTION
This greatly speeds up how long it takes to set-up a Tox environment.

For me, this takes the time to run `tox` (which cached environments) down to ~17 seconds, from around 45 seconds.

Tips taken from: https://hynek.me/articles/turbo-charge-tox/