### PR TITLE
Address mypy errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased changes
 
+- Change type signature of `django_integrity.conversion.refine_integrity_error`.
+  Instead of accepting `Mapping[_Rule, Exception]`, it now accepts `Sequence[tuple[_Rule, Exception | type[Exception]]`.
+  This prevents issues with typing, and removes the need for `_Rule` to be hashable.
 - Fix some more incorrect type signatures:
     - `django_integrity.conversion.Unique.fields` was erroneously `tuple[str]` instead of `tuple[str, ...]`.
 - Protect against previously-unhandled potential `None` in errors from Psycopg.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased changes
 
+- Fix some more incorrect type signatures:
+    - `django_integrity.conversion.Unique.fields` was erroneously `tuple[str]` instead of `tuple[str, ...]`.
+
 ## v0.1.1 - 2024-05-09
 
 - Fix some incorrect type signatures.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file.
 
 - Fix some more incorrect type signatures:
     - `django_integrity.conversion.Unique.fields` was erroneously `tuple[str]` instead of `tuple[str, ...]`.
+- Protect against previously-unhandled potential `None` in errors from Psycopg.
 
 ## v0.1.1 - 2024-05-09
 

--- a/mypy-ratchet.json
+++ b/mypy-ratchet.json
@@ -1,12 +1,9 @@
 {
   "tests/django_integrity/test_conversion.py": {
-    "Argument \"model\" to \"Unique\" has incompatible type \"Unique\"; expected \"type[Model]\"  [arg-type]": 1,
     "Argument 1 to \"refine_integrity_error\" has incompatible type \"dict[ForeignKey, type[SimpleError]]\"; expected \"Mapping[_Rule, Exception]\"  [arg-type]": 3,
     "Argument 1 to \"refine_integrity_error\" has incompatible type \"dict[Named, type[SimpleError]]\"; expected \"Mapping[_Rule, Exception]\"  [arg-type]": 2,
     "Argument 1 to \"refine_integrity_error\" has incompatible type \"dict[NotNull, type[SimpleError]]\"; expected \"Mapping[_Rule, Exception]\"  [arg-type]": 3,
     "Argument 1 to \"refine_integrity_error\" has incompatible type \"dict[PrimaryKey, type[SimpleError]]\"; expected \"Mapping[_Rule, Exception]\"  [arg-type]": 2,
-    "Argument 1 to \"refine_integrity_error\" has incompatible type \"dict[Unique, type[SimpleError]]\"; expected \"Mapping[_Rule, Exception]\"  [arg-type]": 3,
-    "Incompatible type for \"unique_field\" of \"AlternativeUniqueModel\" (got \"None\", expected \"float | int | str | Combinable\")  [misc]": 1,
-    "Incompatible type for \"unique_field\" of \"UniqueModel\" (got \"None\", expected \"float | int | str | Combinable\")  [misc]": 2
+    "Argument 1 to \"refine_integrity_error\" has incompatible type \"dict[Unique, type[SimpleError]]\"; expected \"Mapping[_Rule, Exception]\"  [arg-type]": 3
   }
 }

--- a/mypy-ratchet.json
+++ b/mypy-ratchet.json
@@ -3,7 +3,6 @@
     "Argument 1 to \"match\" of \"Pattern\" has incompatible type \"str | None\"; expected \"str\"  [arg-type]": 3
   },
   "tests/django_integrity/test_conversion.py": {
-    "Argument \"fields\" to \"Unique\" has incompatible type \"tuple[str, str]\"; expected \"tuple[str]\"  [arg-type]": 1,
     "Argument \"model\" to \"Unique\" has incompatible type \"Unique\"; expected \"type[Model]\"  [arg-type]": 1,
     "Argument 1 to \"refine_integrity_error\" has incompatible type \"dict[ForeignKey, type[SimpleError]]\"; expected \"Mapping[_Rule, Exception]\"  [arg-type]": 3,
     "Argument 1 to \"refine_integrity_error\" has incompatible type \"dict[Named, type[SimpleError]]\"; expected \"Mapping[_Rule, Exception]\"  [arg-type]": 2,

--- a/mypy-ratchet.json
+++ b/mypy-ratchet.json
@@ -4,13 +4,11 @@
   },
   "src/django_integrity/constraints.py": {
     "Cannot find implementation or library stub for module named \"psycopg\"  [import-not-found]": 1,
-    "Library stubs not installed for \"psycopg2\"  [import-untyped]": 1,
     "Module has no attribute \"transaction\"  [attr-defined]": 4
   },
   "src/django_integrity/conversion.py": {
     "Cannot find implementation or library stub for module named \"psycopg\"  [import-not-found]": 1,
     "Function is missing a return type annotation  [no-untyped-def]": 1,
-    "Library stubs not installed for \"psycopg2\"  [import-untyped]": 1,
     "Returning Any from function declared to return \"bool\"  [no-any-return]": 2
   },
   "tests/django_integrity/test_conversion.py": {

--- a/mypy-ratchet.json
+++ b/mypy-ratchet.json
@@ -3,13 +3,11 @@
     "Function is missing a return type annotation  [no-untyped-def]": 1
   },
   "src/django_integrity/constraints.py": {
-    "Module has no attribute \"transaction\"  [attr-defined]": 4,
-    "Name \"sql\" already defined (by an import)  [no-redef]": 1
+    "Module has no attribute \"transaction\"  [attr-defined]": 4
   },
   "src/django_integrity/conversion.py": {
     "Argument 1 to \"match\" of \"Pattern\" has incompatible type \"str | None\"; expected \"str\"  [arg-type]": 3,
-    "Function is missing a return type annotation  [no-untyped-def]": 1,
-    "Name \"psycopg\" already defined (by an import)  [no-redef]": 1
+    "Function is missing a return type annotation  [no-untyped-def]": 1
   },
   "tests/django_integrity/test_conversion.py": {
     "Argument \"fields\" to \"Unique\" has incompatible type \"tuple[str, str]\"; expected \"tuple[str]\"  [arg-type]": 1,

--- a/mypy-ratchet.json
+++ b/mypy-ratchet.json
@@ -1,7 +1,4 @@
 {
-  "scripts/verify-version-tag.py": {
-    "Function is missing a return type annotation  [no-untyped-def]": 1
-  },
   "src/django_integrity/constraints.py": {
     "Module has no attribute \"transaction\"  [attr-defined]": 4
   },

--- a/mypy-ratchet.json
+++ b/mypy-ratchet.json
@@ -1,7 +1,6 @@
 {
   "src/django_integrity/conversion.py": {
-    "Argument 1 to \"match\" of \"Pattern\" has incompatible type \"str | None\"; expected \"str\"  [arg-type]": 3,
-    "Function is missing a return type annotation  [no-untyped-def]": 1
+    "Argument 1 to \"match\" of \"Pattern\" has incompatible type \"str | None\"; expected \"str\"  [arg-type]": 3
   },
   "tests/django_integrity/test_conversion.py": {
     "Argument \"fields\" to \"Unique\" has incompatible type \"tuple[str, str]\"; expected \"tuple[str]\"  [arg-type]": 1,

--- a/mypy-ratchet.json
+++ b/mypy-ratchet.json
@@ -1,7 +1,4 @@
 {
-  "src/django_integrity/constraints.py": {
-    "Module has no attribute \"transaction\"  [attr-defined]": 4
-  },
   "src/django_integrity/conversion.py": {
     "Argument 1 to \"match\" of \"Pattern\" has incompatible type \"str | None\"; expected \"str\"  [arg-type]": 3,
     "Function is missing a return type annotation  [no-untyped-def]": 1

--- a/mypy-ratchet.json
+++ b/mypy-ratchet.json
@@ -13,9 +13,6 @@
     "Library stubs not installed for \"psycopg2\"  [import-untyped]": 1,
     "Returning Any from function declared to return \"bool\"  [no-any-return]": 2
   },
-  "tests/django_integrity/test_constraints.py": {
-    "Function is missing a return type annotation  [no-untyped-def]": 13
-  },
   "tests/django_integrity/test_conversion.py": {
     "Argument \"fields\" to \"Unique\" has incompatible type \"tuple[str, str]\"; expected \"tuple[str]\"  [arg-type]": 1,
     "Argument \"model\" to \"Unique\" has incompatible type \"Unique\"; expected \"type[Model]\"  [arg-type]": 1,

--- a/mypy-ratchet.json
+++ b/mypy-ratchet.json
@@ -3,13 +3,13 @@
     "Function is missing a return type annotation  [no-untyped-def]": 1
   },
   "src/django_integrity/constraints.py": {
-    "Cannot find implementation or library stub for module named \"psycopg\"  [import-not-found]": 1,
-    "Module has no attribute \"transaction\"  [attr-defined]": 4
+    "Module has no attribute \"transaction\"  [attr-defined]": 4,
+    "Name \"sql\" already defined (by an import)  [no-redef]": 1
   },
   "src/django_integrity/conversion.py": {
-    "Cannot find implementation or library stub for module named \"psycopg\"  [import-not-found]": 1,
+    "Argument 1 to \"match\" of \"Pattern\" has incompatible type \"str | None\"; expected \"str\"  [arg-type]": 3,
     "Function is missing a return type annotation  [no-untyped-def]": 1,
-    "Returning Any from function declared to return \"bool\"  [no-any-return]": 2
+    "Name \"psycopg\" already defined (by an import)  [no-redef]": 1
   },
   "tests/django_integrity/test_conversion.py": {
     "Argument \"fields\" to \"Unique\" has incompatible type \"tuple[str, str]\"; expected \"tuple[str]\"  [arg-type]": 1,

--- a/mypy-ratchet.json
+++ b/mypy-ratchet.json
@@ -1,9 +1,1 @@
-{
-  "tests/django_integrity/test_conversion.py": {
-    "Argument 1 to \"refine_integrity_error\" has incompatible type \"dict[ForeignKey, type[SimpleError]]\"; expected \"Mapping[_Rule, Exception]\"  [arg-type]": 3,
-    "Argument 1 to \"refine_integrity_error\" has incompatible type \"dict[Named, type[SimpleError]]\"; expected \"Mapping[_Rule, Exception]\"  [arg-type]": 2,
-    "Argument 1 to \"refine_integrity_error\" has incompatible type \"dict[NotNull, type[SimpleError]]\"; expected \"Mapping[_Rule, Exception]\"  [arg-type]": 3,
-    "Argument 1 to \"refine_integrity_error\" has incompatible type \"dict[PrimaryKey, type[SimpleError]]\"; expected \"Mapping[_Rule, Exception]\"  [arg-type]": 2,
-    "Argument 1 to \"refine_integrity_error\" has incompatible type \"dict[Unique, type[SimpleError]]\"; expected \"Mapping[_Rule, Exception]\"  [arg-type]": 3
-  }
-}
+{}

--- a/mypy-ratchet.json
+++ b/mypy-ratchet.json
@@ -24,8 +24,6 @@
     "Argument 1 to \"refine_integrity_error\" has incompatible type \"dict[NotNull, type[SimpleError]]\"; expected \"Mapping[_Rule, Exception]\"  [arg-type]": 3,
     "Argument 1 to \"refine_integrity_error\" has incompatible type \"dict[PrimaryKey, type[SimpleError]]\"; expected \"Mapping[_Rule, Exception]\"  [arg-type]": 2,
     "Argument 1 to \"refine_integrity_error\" has incompatible type \"dict[Unique, type[SimpleError]]\"; expected \"Mapping[_Rule, Exception]\"  [arg-type]": 3,
-    "Function is missing a return type annotation  [no-untyped-def]": 14,
-    "Function is missing a type annotation  [no-untyped-def]": 1,
     "Incompatible type for \"unique_field\" of \"AlternativeUniqueModel\" (got \"None\", expected \"float | int | str | Combinable\")  [misc]": 1,
     "Incompatible type for \"unique_field\" of \"UniqueModel\" (got \"None\", expected \"float | int | str | Combinable\")  [misc]": 2
   }

--- a/mypy-ratchet.json
+++ b/mypy-ratchet.json
@@ -1,7 +1,4 @@
 {
-  "src/django_integrity/conversion.py": {
-    "Argument 1 to \"match\" of \"Pattern\" has incompatible type \"str | None\"; expected \"str\"  [arg-type]": 3
-  },
   "tests/django_integrity/test_conversion.py": {
     "Argument \"model\" to \"Unique\" has incompatible type \"Unique\"; expected \"type[Model]\"  [arg-type]": 1,
     "Argument 1 to \"refine_integrity_error\" has incompatible type \"dict[ForeignKey, type[SimpleError]]\"; expected \"Mapping[_Rule, Exception]\"  [arg-type]": 3,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,7 @@ dev = [
     "pytest",
     "pytest-django",
     "tox",
+    "types-psycopg2",
 
     # Linting
     "mypy",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ dev = [
     "django-stubs",
     "environs",
     "psycopg2-binary",
+    "psycopg[binary]",
     "pytest",
     "pytest-django",
     "tox",

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -66,6 +66,10 @@ pluggy==1.5.0
     # via
     #   pytest
     #   tox
+psycopg==3.1.18
+    # via django_integrity (pyproject.toml)
+psycopg-binary==3.1.18
+    # via psycopg
 psycopg2-binary==2.9.9
     # via django_integrity (pyproject.toml)
 pygments==2.18.0
@@ -113,6 +117,7 @@ typing-extensions==4.11.0
     #   django-stubs
     #   django-stubs-ext
     #   mypy
+    #   psycopg
     #   typer
 virtualenv==20.26.1
     # via tox

--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -102,6 +102,8 @@ tox==4.15.0
     # via django_integrity (pyproject.toml)
 typer==0.12.3
     # via django_integrity (pyproject.toml)
+types-psycopg2==2.9.21.20240417
+    # via django_integrity (pyproject.toml)
 types-pyyaml==6.0.12.20240311
     # via django-stubs
 typing-extensions==4.11.0

--- a/scripts/verify-version-tag.py
+++ b/scripts/verify-version-tag.py
@@ -29,7 +29,7 @@ app = typer.Typer()
 
 
 @app.command()
-def main():
+def main() -> None:
     # Get the tags on the current commit.
     tags = (
         subprocess.check_output(["git", "tag", "--points-at", "HEAD"]).decode().split()

--- a/src/django_integrity/constraints.py
+++ b/src/django_integrity/constraints.py
@@ -7,7 +7,7 @@ from django import db as django_db
 try:
     from psycopg import sql
 except ImportError:
-    from psycopg2 import sql
+    from psycopg2 import sql  # type: ignore[no-redef]
 
 
 # Note [Deferrable constraints]

--- a/src/django_integrity/constraints.py
+++ b/src/django_integrity/constraints.py
@@ -1,7 +1,7 @@
 import contextlib
 from collections.abc import Iterator, Sequence
 
-from django import db as django_db
+from django.db import connections, models, transaction
 
 
 try:
@@ -69,7 +69,7 @@ def immediate(names: Sequence[str], *, using: str) -> Iterator[None]:
     """
     set_immediate(names, using=using)
     try:
-        with django_db.transaction.atomic(using=using):
+        with transaction.atomic(using=using):
             yield
     finally:
         set_deferred(names, using=using)
@@ -87,10 +87,10 @@ def set_all_immediate(*, using: str) -> None:
     Raises:
         NotInTransaction: When we try to change constraints outside of a transaction.
     """
-    if django_db.transaction.get_autocommit(using):
+    if transaction.get_autocommit(using):
         raise NotInTransaction
 
-    with django_db.connections[using].cursor() as cursor:
+    with connections[using].cursor() as cursor:
         cursor.execute("SET CONSTRAINTS ALL IMMEDIATE")
 
 
@@ -107,7 +107,7 @@ def set_immediate(names: Sequence[str], *, using: str) -> None:
     Raises:
         NotInTransaction: When we try to change constraints outside of a transaction.
     """
-    if django_db.transaction.get_autocommit(using):
+    if transaction.get_autocommit(using):
         raise NotInTransaction
 
     if not names:
@@ -117,7 +117,7 @@ def set_immediate(names: Sequence[str], *, using: str) -> None:
         names=sql.SQL(", ").join(sql.Identifier(name) for name in names)
     )
 
-    with django_db.connections[using].cursor() as cursor:
+    with connections[using].cursor() as cursor:
         cursor.execute(query)
 
 
@@ -134,7 +134,7 @@ def set_deferred(names: Sequence[str], *, using: str) -> None:
     Raises:
         NotInTransaction: When we try to change constraints outside of a transaction.
     """
-    if django_db.transaction.get_autocommit(using):
+    if transaction.get_autocommit(using):
         raise NotInTransaction
 
     if not names:
@@ -144,7 +144,7 @@ def set_deferred(names: Sequence[str], *, using: str) -> None:
         names=sql.SQL(", ").join(sql.Identifier(name) for name in names)
     )
 
-    with django_db.connections[using].cursor() as cursor:
+    with connections[using].cursor() as cursor:
         cursor.execute(query)
 
 
@@ -160,7 +160,7 @@ class NotInTransaction(Exception):
 
 
 def foreign_key_constraint_name(
-    model: type[django_db.models.Model], field_name: str, *, using: str
+    model: type[models.Model], field_name: str, *, using: str
 ) -> str:
     """
     Calculate FK constraint name for a model's field.
@@ -195,7 +195,7 @@ def foreign_key_constraint_name(
     to_field = remote_field.name
     suffix = f"_fk_{to_table}_{to_field}"
 
-    connection = django_db.connections[using]
+    connection = connections[using]
     with connection.schema_editor() as editor:
         # The _fk_constraint_name method is not part of the public API,
         # and only exists on the PostgreSQL schema editor.

--- a/src/django_integrity/conversion.py
+++ b/src/django_integrity/conversion.py
@@ -83,7 +83,7 @@ class Unique(_Rule):
         if not isinstance(error.__cause__, psycopg.errors.UniqueViolation):
             return False
 
-        match = self._pattern.match(error.__cause__.diag.message_detail)
+        match = self._pattern.match(error.__cause__.diag.message_detail or "")
         if match is None:
             return False
 
@@ -122,7 +122,7 @@ class PrimaryKey(_Rule):
         if not isinstance(error.__cause__, psycopg.errors.UniqueViolation):
             return False
 
-        match = self._pattern.match(error.__cause__.diag.message_detail)
+        match = self._pattern.match(error.__cause__.diag.message_detail or "")
         if match is None:
             return False
 
@@ -179,7 +179,9 @@ class ForeignKey(_Rule):
         if not isinstance(error.__cause__, psycopg.errors.ForeignKeyViolation):
             return False
 
-        detail_match = self._detail_pattern.match(error.__cause__.diag.message_detail)
+        detail_match = self._detail_pattern.match(
+            error.__cause__.diag.message_detail or ""
+        )
         if detail_match is None:
             return False
 

--- a/src/django_integrity/conversion.py
+++ b/src/django_integrity/conversion.py
@@ -4,7 +4,7 @@ import abc
 import contextlib
 import dataclasses
 import re
-from collections.abc import Iterator, Mapping
+from collections.abc import Iterator, Sequence
 
 from django import db as django_db
 
@@ -16,23 +16,26 @@ except ImportError:
 
 
 @contextlib.contextmanager
-def refine_integrity_error(rules: Mapping[_Rule, Exception]) -> Iterator[None]:
+def refine_integrity_error(
+    rules: Sequence[tuple[_Rule, Exception | type[Exception]]],
+) -> Iterator[None]:
     """
     Convert a generic IntegrityError into a more specific exception.
 
-    The conversion is based on a mapping of rules to exceptions.
+    The conversion is based on (rule, exception) pairs.
 
     Args:
-        rules: A mapping of rules to the exceptions we'll raise if they match.
+        rules: A sequence of rule, exception pairs.
+            If the rule matches the IntegrityError, the exception is raised.
 
     Raises:
-        An error from the rules mapping if an IntegrityError matches a rule.
+        The exception paired with the first matching rule.
         Otherwise, the original IntegrityError.
     """
     try:
         yield
     except django_db.IntegrityError as e:
-        for rule, refined_error in rules.items():
+        for rule, refined_error in rules:
             if rule.is_match(e):
                 raise refined_error from e
         raise

--- a/src/django_integrity/conversion.py
+++ b/src/django_integrity/conversion.py
@@ -106,7 +106,7 @@ class PrimaryKey(_Rule):
 
     _pattern = re.compile(r"Key \((?P<fields>.+)\)=\(.*\) already exists.")
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """
         Ensure the model has a primary key.
 

--- a/src/django_integrity/conversion.py
+++ b/src/django_integrity/conversion.py
@@ -12,7 +12,7 @@ from django import db as django_db
 try:
     import psycopg
 except ImportError:
-    import psycopg2 as psycopg
+    import psycopg2 as psycopg  # type: ignore[no-redef]
 
 
 @contextlib.contextmanager

--- a/src/django_integrity/conversion.py
+++ b/src/django_integrity/conversion.py
@@ -75,7 +75,7 @@ class Unique(_Rule):
     """
 
     model: type[django_db.models.Model]
-    fields: tuple[str]
+    fields: tuple[str, ...]
 
     _pattern = re.compile(r"Key \((?P<fields>.+)\)=\(.*\) already exists.")
 

--- a/tests/django_integrity/test_constraints.py
+++ b/tests/django_integrity/test_constraints.py
@@ -41,7 +41,7 @@ class TestForeignKeyConstraintName:
 
 class TestSetAllImmediate:
     @pytest.mark.django_db
-    def test_all_constraints_set(self):
+    def test_all_constraints_set(self) -> None:
         constraints.set_all_immediate(using="default")
 
         with pytest.raises(django_db.IntegrityError):
@@ -50,7 +50,7 @@ class TestSetAllImmediate:
 
     @pytest.mark.django_db
     @pytest.mark.xfail(raises=django_db.IntegrityError)
-    def test_constraint_not_set(self):
+    def test_constraint_not_set(self) -> None:
         # This try block proves that the constraint isn't enforced immediately.
         # It's deferred, so the error is raised in the shutdown phase of the test.
         # We use xfail to catch the error and prevent the test from failing.
@@ -60,7 +60,7 @@ class TestSetAllImmediate:
             pytest.fail("The ForeignKey constraint should be deferred.")
 
     @pytest.mark.django_db(transaction=True)
-    def test_not_in_transaction(self):
+    def test_not_in_transaction(self) -> None:
         # Fail if we're not in a transaction.
         with pytest.raises(constraints.NotInTransaction):
             constraints.set_all_immediate(using="default")
@@ -68,7 +68,7 @@ class TestSetAllImmediate:
 
 class TestSetImmediate:
     @pytest.mark.django_db
-    def test_set(self):
+    def test_set(self) -> None:
         constraint_name = constraints.foreign_key_constraint_name(
             model=test_models.ForeignKeyModel,
             field_name="related_id",
@@ -82,7 +82,7 @@ class TestSetImmediate:
             test_models.ForeignKeyModel.objects.create(related_id=42)
 
     @pytest.mark.django_db
-    def test_not_set(self):
+    def test_not_set(self) -> None:
         # No constraint name is passed, so no constraints should be set to immediate.
         constraints.set_immediate(names=(), using="default")
 
@@ -94,7 +94,7 @@ class TestSetImmediate:
             constraints.set_all_immediate(using="default")
 
     @pytest.mark.django_db(transaction=True)
-    def test_not_in_transaction(self):
+    def test_not_in_transaction(self) -> None:
         # Fail if we're not in a transaction.
         with pytest.raises(constraints.NotInTransaction):
             constraints.set_immediate(names=(), using="default")
@@ -102,7 +102,7 @@ class TestSetImmediate:
 
 class TestSetDeferred:
     @pytest.mark.django_db
-    def test_not_set(self):
+    def test_not_set(self) -> None:
         test_models.UniqueModel.objects.create(unique_field=42)
 
         # We pass no names, so no constraints should be set to deferred.
@@ -114,7 +114,7 @@ class TestSetDeferred:
             test_models.UniqueModel.objects.create(unique_field=42)
 
     @pytest.mark.django_db
-    def test_set(self):
+    def test_set(self) -> None:
         test_models.UniqueModel.objects.create(unique_field=42)
 
         # We defer the constraint...
@@ -129,7 +129,7 @@ class TestSetDeferred:
             constraints.set_all_immediate(using="default")
 
     @pytest.mark.django_db(transaction=True)
-    def test_not_in_transaction(self):
+    def test_not_in_transaction(self) -> None:
         # Fail if we're not in a transaction.
         with pytest.raises(constraints.NotInTransaction):
             constraints.set_deferred(names=(), using="default")
@@ -137,7 +137,7 @@ class TestSetDeferred:
 
 class TestImmediate:
     @pytest.mark.django_db
-    def test_constraint_not_enforced(self):
+    def test_constraint_not_enforced(self) -> None:
         """Constraints are not changed when not explicitly enforced."""
         # Call the context manager without any constraint names.
         with constraints.immediate((), using="default"):
@@ -150,7 +150,7 @@ class TestImmediate:
             constraints.set_all_immediate(using="default")
 
     @pytest.mark.django_db
-    def test_constraint_enforced(self):
+    def test_constraint_enforced(self) -> None:
         """Constraints are enforced when explicitly enforced."""
         constraint_name = constraints.foreign_key_constraint_name(
             model=test_models.ForeignKeyModel,
@@ -173,7 +173,7 @@ class TestImmediate:
         assert context_manager_successfully_entered is True
 
     @pytest.mark.django_db
-    def test_deferral_restored(self):
+    def test_deferral_restored(self) -> None:
         """Constraints are restored to DEFERRED after the context manager."""
         constraint_name = constraints.foreign_key_constraint_name(
             model=test_models.ForeignKeyModel,
@@ -193,7 +193,7 @@ class TestImmediate:
             constraints.set_all_immediate(using="default")
 
     @pytest.mark.django_db(transaction=True)
-    def test_not_in_transaction(self):
+    def test_not_in_transaction(self) -> None:
         # Fail if we're not in a transaction.
         with pytest.raises(constraints.NotInTransaction):
             with constraints.immediate((), using="default"):

--- a/tests/django_integrity/test_conversion.py
+++ b/tests/django_integrity/test_conversion.py
@@ -10,7 +10,7 @@ class SimpleError(Exception):
 
 
 class TestRefineIntegrityError:
-    def test_no_rules(self):
+    def test_no_rules(self) -> None:
         # It is legal to call the context manager without any rules.
         with conversion.refine_integrity_error(rules={}):
             pass
@@ -18,7 +18,7 @@ class TestRefineIntegrityError:
 
 @pytest.mark.django_db
 class TestNamedConstraint:
-    def test_error_refined(self):
+    def test_error_refined(self) -> None:
         # Create a unique instance so that we can violate the constraint later.
         test_models.UniqueModel.objects.create(unique_field=42)
 
@@ -29,7 +29,7 @@ class TestNamedConstraint:
             with conversion.refine_integrity_error(rules):
                 test_models.UniqueModel.objects.create(unique_field=42)
 
-    def test_rules_mismatch(self):
+    def test_rules_mismatch(self) -> None:
         # Create a unique instance so that we can violate the constraint later.
         test_models.UniqueModel.objects.create(unique_field=42)
 
@@ -44,7 +44,7 @@ class TestNamedConstraint:
 
 @pytest.mark.django_db
 class TestUnique:
-    def test_error_refined(self):
+    def test_error_refined(self) -> None:
         # Create a unique instance so that we can violate the constraint later.
         test_models.UniqueModel.objects.create(unique_field=42)
 
@@ -59,7 +59,7 @@ class TestUnique:
             with conversion.refine_integrity_error(rules):
                 test_models.UniqueModel.objects.create(unique_field=42)
 
-    def test_multiple_fields(self):
+    def test_multiple_fields(self) -> None:
         # Create a unique instance so that we can violate the constraint later.
         test_models.UniqueTogetherModel.objects.create(field_1=1, field_2=2)
 
@@ -90,7 +90,7 @@ class TestUnique:
         ),
         ids=("wrong_model", "wrong_field"),
     )
-    def test_rules_mismatch(self, Model: conversion.Unique, field: str):
+    def test_rules_mismatch(self, Model: conversion.Unique, field: str) -> None:
         # A rule that matches a similar looking, but different, unique constraint.
         # Create a unique instance so that we can violate the constraint later.
         test_models.UniqueModel.objects.create(unique_field=42)
@@ -112,7 +112,11 @@ class TestPrimaryKey:
             test_models.AlternativePrimaryKeyModel,
         ),
     )
-    def test_error_refined(self, ModelClass):
+    def test_error_refined(
+        self,
+        ModelClass: type[test_models.PrimaryKeyModel]
+        | type[test_models.AlternativePrimaryKeyModel],
+    ) -> None:
         """
         The primary key of a model is extracted from the model.
 
@@ -131,7 +135,7 @@ class TestPrimaryKey:
             with conversion.refine_integrity_error(rules):
                 ModelClass.objects.create(pk=existing_primary_key)
 
-    def test_rules_mismatch(self):
+    def test_rules_mismatch(self) -> None:
         # Create a unique instance so that we can violate the constraint later.
         existing_primary_key = test_models.PrimaryKeyModel.objects.create().pk
 
@@ -143,7 +147,7 @@ class TestPrimaryKey:
             with conversion.refine_integrity_error(rules):
                 test_models.PrimaryKeyModel.objects.create(pk=existing_primary_key)
 
-    def test_model_without_primary_key(self):
+    def test_model_without_primary_key(self) -> None:
         """
         We cannot create a PrimaryKey rule for a model without a primary key.
         """
@@ -156,7 +160,7 @@ class TestPrimaryKey:
 
 @pytest.mark.django_db
 class TestNotNull:
-    def test_error_refined(self):
+    def test_error_refined(self) -> None:
         rules = {
             conversion.NotNull(
                 model=test_models.UniqueModel, field="unique_field"
@@ -168,7 +172,7 @@ class TestNotNull:
             with conversion.refine_integrity_error(rules):
                 test_models.UniqueModel.objects.create(unique_field=None)
 
-    def test_model_mismatch(self):
+    def test_model_mismatch(self) -> None:
         # Same field, but different model.
         rules = {
             conversion.NotNull(
@@ -180,7 +184,7 @@ class TestNotNull:
             with conversion.refine_integrity_error(rules):
                 test_models.UniqueModel.objects.create(unique_field=None)
 
-    def test_field_mismatch(self):
+    def test_field_mismatch(self) -> None:
         # Same model, but different field.
         rules = {
             conversion.NotNull(
@@ -199,7 +203,7 @@ class TestNotNull:
 
 @pytest.mark.django_db
 class TestForeignKey:
-    def test_error_refined(self):
+    def test_error_refined(self) -> None:
         rules = {
             conversion.ForeignKey(
                 model=test_models.ForeignKeyModel, field="related_id"
@@ -213,7 +217,7 @@ class TestForeignKey:
                 # Create a ForeignKeyModel with a related_id that doesn't exist.
                 test_models.ForeignKeyModel.objects.create(related_id=42)
 
-    def test_source_mismatch(self):
+    def test_source_mismatch(self) -> None:
         # The field name matches, but the source model is different.
         rules = {
             conversion.ForeignKey(
@@ -226,7 +230,7 @@ class TestForeignKey:
             with conversion.refine_integrity_error(rules):
                 test_models.ForeignKeyModel.objects.create(related_id=42)
 
-    def test_field_mismatch(self):
+    def test_field_mismatch(self) -> None:
         # The source model matches, but the field name is different.
         rules = {
             conversion.ForeignKey(

--- a/tests/django_integrity/test_conversion.py
+++ b/tests/django_integrity/test_conversion.py
@@ -174,7 +174,8 @@ class TestNotNull:
         # The original error should be transformed into our expected error.
         with pytest.raises(SimpleError):
             with conversion.refine_integrity_error(rules):
-                test_models.UniqueModel.objects.create(unique_field=None)
+                # We ignore the type error because it's picking up on the error we're testing.
+                test_models.UniqueModel.objects.create(unique_field=None)  # type: ignore[misc]
 
     def test_model_mismatch(self) -> None:
         # Same field, but different model.
@@ -186,7 +187,8 @@ class TestNotNull:
 
         with pytest.raises(django_db.IntegrityError):
             with conversion.refine_integrity_error(rules):
-                test_models.UniqueModel.objects.create(unique_field=None)
+                # We ignore the type error because it's picking up on the error we're testing.
+                test_models.UniqueModel.objects.create(unique_field=None)  # type: ignore[misc]
 
     def test_field_mismatch(self) -> None:
         # Same model, but different field.
@@ -200,7 +202,8 @@ class TestNotNull:
         with pytest.raises(django_db.IntegrityError):
             with conversion.refine_integrity_error(rules):
                 test_models.AlternativeUniqueModel.objects.create(
-                    unique_field=None,
+                    # We ignore the type error because it's picking up on the error we're testing.
+                    unique_field=None,  # type: ignore[misc]
                     unique_field_2=42,
                 )
 

--- a/tests/django_integrity/test_conversion.py
+++ b/tests/django_integrity/test_conversion.py
@@ -90,7 +90,11 @@ class TestUnique:
         ),
         ids=("wrong_model", "wrong_field"),
     )
-    def test_rules_mismatch(self, Model: conversion.Unique, field: str) -> None:
+    def test_rules_mismatch(
+        self,
+        Model: type[test_models.AlternativeUniqueModel | test_models.UniqueModel],
+        field: str,
+    ) -> None:
         # A rule that matches a similar looking, but different, unique constraint.
         # Create a unique instance so that we can violate the constraint later.
         test_models.UniqueModel.objects.create(unique_field=42)


### PR DESCRIPTION
For a while Mypy wasn't running in CI.

This addresses the errors which accumulated in that time.

Some backwards-incompatible changes have been made to the API in order to fix these type errors. Most pointedly, `refine_integrity_error` now takes a sequence of rule-exception 2-tuples instead of a mapping of rule to exception.