### PR TITLE
Rework xfail test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,5 +156,7 @@ django_settings_module = "tests.example_app.settings"
 [tool.pytest.ini_options]
 # Ensure error warnings are converted into test errors.
 filterwarnings = "error"
+# Ensure that tests fail if an xfail test unexpectedly passes.
+xfail_strict = true
 
 DJANGO_SETTINGS_MODULE = "tests.example_app.settings"


### PR DESCRIPTION
Before this change, this test used Django's test transaction to catch the failure outside the body of the test.

This was unreliable. The test passed CI even when the test body was removed.

This change reworks the test so that the entirety of the tested logic is inside the test, and updates the pytest settings to ensure that passing xfail tests fail CI.

Fixes #12.