### PR TITLE
Prepare for v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased changes
 
+## v0.2.0 - 2024-05-13
+
 - Change type signature of `django_integrity.conversion.refine_integrity_error`.
   Instead of accepting `Mapping[_Rule, Exception]`, it now accepts `Sequence[tuple[_Rule, Exception | type[Exception]]`.
   This prevents issues with typing, and removes the need for `_Rule` to be hashable.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,18 @@ All notable changes to this project will be documented in this file.
 
 ## v0.2.0 - 2024-05-13
 
+### Changed
+
 - Change type signature of `django_integrity.conversion.refine_integrity_error`.
   Instead of accepting `Mapping[_Rule, Exception]`, it now accepts `Sequence[tuple[_Rule, Exception | type[Exception]]`.
   This prevents issues with typing, and removes the need for `_Rule` to be hashable.
+- Install CI and development requirements with `uv` instead of `pip-tools`.
+
+### Fixed
+
 - Fix some more incorrect type signatures:
     - `django_integrity.conversion.Unique.fields` was erroneously `tuple[str]` instead of `tuple[str, ...]`.
 - Protect against previously-unhandled potential `None` in errors from Psycopg.
-- Install CI and development requirements with `uv` instead of `pip-tools`.
 
 ## v0.1.1 - 2024-05-09
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ where = ["src"]
 
 [project]
 name = "django_integrity"
-version = "0.1.1"
+version = "0.2.0"
 description = "Tools for refining Django's IntegrityError, and working with deferred database constraints."
 license.file = "LICENSE"
 readme = "README.md"


### PR DESCRIPTION
This bumps the version so that we can make a release.

From the changelog:

- Change type signature of `django_integrity.conversion.refine_integrity_error`.
  Instead of accepting `Mapping[_Rule, Exception]`, it now accepts `Sequence[tuple[_Rule, Exception | type[Exception]]`.
  This prevents issues with typing, and removes the need for `_Rule` to be hashable.
- Fix some more incorrect type signatures:
    - `django_integrity.conversion.Unique.fields` was erroneously `tuple[str]` instead of `tuple[str, ...]`.
- Protect against previously-unhandled potential `None` in errors from Psycopg.
- Install CI and development requirements with `uv` instead of `pip-tools`.