### PR TITLE
Add missing release requirement

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ pytest-in-tox = [
     "pytest>=8.2.0",
 ]
 release = [
+    "packaging>=24.0",
     "rich>=13.7.1",
     "tomli >= 1.1.0 ; python_version < '3.11'",
     "typer>=0.12.3",
@@ -90,6 +91,7 @@ dev = [
     "pre-commit>=3.7.0",
 
     # CLI utils
+    "packaging>=24.0",
     "rich>=13.7.1",
     "tomli >= 1.1.0 ; python_version < '3.11'",
     "typer>=0.12.3",

--- a/requirements/release.txt
+++ b/requirements/release.txt
@@ -6,6 +6,7 @@ markdown-it-py==3.0.0
     # via rich
 mdurl==0.1.2
     # via markdown-it-py
+packaging==24.0
 pygments==2.18.0
     # via rich
 rich==13.7.1


### PR DESCRIPTION
Before this change, we saw an error in CI when we tried to make a release:

    ModuleNotFoundError: No module named 'packaging'

Ref: https://github.com/kraken-tech/django-integrity/actions/runs/9062077439/job/24895172273