### PR TITLE
Use validate-commits to check commits are valid

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -67,3 +67,24 @@ jobs:
           tox --parallel --parallel-no-spinner --skip-missing-interpreters=false
         env:
           DATABASE_URL: postgres://postgres:postgres@localhost/django_integrity
+
+  validate_commits:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 5
+
+    # Only check commits on PR branches, where they can be changed.
+    if: github.event_name == 'pull_request'
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ github.head_ref }}
+          fetch-depth: 0
+      - run: |
+          git fetch origin main
+          git branch main origin/main
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.14"
+      - run: pip install validate_commits
+      - run: validate-commits


### PR DESCRIPTION
We only use the default/builtin rules, which are sufficient for our
purposes.
